### PR TITLE
add Python version / package versions?

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is currently still "work in progress".
 
 The robot uses Ubuntu 20.04 and ROS noetic. 
 So make sure that it is installed on your system.
-Visit the [ROS Wiki](http://wiki.ros.org/noetic/Installation) for further details. For Python version 3.10 is used.
+Visit the [ROS Wiki](http://wiki.ros.org/noetic/Installation) for further details. For Python version 3.8 is used.
 
 Remember to source the ROS noetic installation in EACH terminal you use or add it once to your `.bashrc` file like this:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is currently still "work in progress".
 
 The robot uses Ubuntu 20.04 and ROS noetic. 
 So make sure that it is installed on your system.
-Visit the [ROS Wiki](http://wiki.ros.org/noetic/Installation) for further details.
+Visit the [ROS Wiki](http://wiki.ros.org/noetic/Installation) for further details. For Python version 3.10 is used.
 
 Remember to source the ROS noetic installation in EACH terminal you use or add it once to your `.bashrc` file like this:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ Pillow==9.4.0
 pytorch_lightning==1.8.1
 torch==1.13.1
 tqdm==4.64.0
-transformers==4.25.1
-sentencepiece
+transformers[sentencepiece]==4.25.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-abjad==3.15
+abjad==3.4
 nltk==3.7
 numpy==1.23.3
 Pillow==9.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-abjad
-numpy
-tqdm
-nltk
-pillow
-pytorch-lightning
-torch
-transformers
+abjad==3.15
+nltk==3.7
+numpy==1.23.3
+Pillow==9.4.0
+pytorch_lightning==1.8.1
+torch==1.13.0
+tqdm==4.64.0
+transformers==4.20.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ nltk==3.7
 numpy==1.23.3
 Pillow==9.4.0
 pytorch_lightning==1.8.1
-torch==1.13.0
+torch==1.13.1
 tqdm==4.64.0
-transformers==4.20.1
+transformers==4.25.1
+sentencepiece


### PR DESCRIPTION
I would like to add the Python version / package versions. It seems that some packages only work on Python 3.10. I added that in the docs. I guess it would make sense to add package versions as well, @Flova  could you help me out or even add them here when appropriate?